### PR TITLE
build: port package scripts to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "npm run build && ./bin/dev-ui.js",
-    "develop": "concurrently \"micro-dev --ignore=/dist\\|/ui\" \"parcel watch index.html --public-url ./\"",
+    "start": "yarn build && ./bin/dev-ui.js",
+    "develop": "concurrently \"yarn develop:server\" \"yarn develop:ui\"",
+    "develop:server": "micro-dev --ignore=\"/dist|/ui\"",
+    "develop:ui": "parcel watch index.html --public-url ./",
     "build": "parcel build index.html --public-url ./",
     "test": "jest",
     "lint": "eslint . --ext=js,jsx --ignore-path=.gitignore",


### PR DESCRIPTION
<!--

Thanks for your pull request! 🎊

-->

## Checklist

* [x] tests pass (`yarn test; yarn lint`)
* [x] I'm in `all-contributors` <!-- yarn all-contributors add myself what,i,did -->

# What's changed?

The `--ignore=/dist|/ui` was causing a pipe to `/ui` on Windows, pulled it out from concurrently and into a new sub-script. This will have a minor cost to boot but is more portable.

## Test plan

Tested script on both Windows and macOS.
