### PR TITLE
refactor: use core-js instead of lodash

### DIFF
--- a/__mocks__/execa.js
+++ b/__mocks__/execa.js
@@ -1,0 +1,14 @@
+const mockStream = () => ({
+  once: jest.fn(),
+  on: jest.fn(),
+  removeListener: jest.fn(),
+  pipe: jest.fn(),
+});
+
+const mockExeca = jest.fn().mockReturnValue({
+  stdout: mockStream(),
+  stderr: mockStream(),
+  kill: () => {},
+});
+
+module.exports = mockExeca;

--- a/__mocks__/has-yarn.js
+++ b/__mocks__/has-yarn.js
@@ -1,0 +1,4 @@
+let hasYarn = false;
+
+module.exports = () => hasYarn;
+module.exports.__setHasYarn = value => (hasYarn = !!value);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require('./src/polyfills');
+
 const cors = require('micro-cors')();
 const serveStatic = require('./src/serve')(__dirname + '/dist');
 const match = require('fs-router')(__dirname + '/routes');

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "dependencies": {
     "ansi-html-stream": "^0.0.3",
+    "core-js": "^2.5.3",
     "execa": "^0.8.0",
     "fs-router": "^0.4.0",
     "get-monorepo-packages": "^1.0.1",
     "get-port": "^3.2.0",
     "has-yarn": "^1.0.0",
-    "lodash": "^4.17.4",
     "merge-stream": "^1.0.1",
     "micro": "^9.0.2",
     "micro-cors": "^0.0.4",

--- a/src/__tests__/ansiCommandStream.test.js
+++ b/src/__tests__/ansiCommandStream.test.js
@@ -1,0 +1,45 @@
+import hasYarn from 'has-yarn';
+import execa from 'execa';
+
+import ansiCommandStream from '../ansiCommandStream';
+
+jest.mock('has-yarn');
+jest.mock('execa');
+
+describe('ansiCommandStream()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when yarn is installed use `yarn remove`', () => {
+    hasYarn.__setHasYarn(true);
+    ansiCommandStream({ args: ['remove', 'lodash'] });
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith('yarn', ['remove', 'lodash']);
+  });
+
+  test('when yarn is not installed use `npm uninstall`', () => {
+    hasYarn.__setHasYarn(false);
+    ansiCommandStream({ args: ['remove', 'lodash'] });
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith('npm', ['uninstall', 'lodash']);
+  });
+
+  test('when yarn is installed use `yarn add`', () => {
+    hasYarn.__setHasYarn(true);
+    ansiCommandStream({ args: ['add', 'lodash'] });
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith('yarn', ['add', 'lodash']);
+  });
+
+  test('when yarn is not installed use `npm install --save`', () => {
+    hasYarn.__setHasYarn(false);
+    ansiCommandStream({ args: ['add', 'lodash'] });
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith('npm', ['install', '--save', 'lodash']);
+  });
+});

--- a/src/ansiCommandStream.js
+++ b/src/ansiCommandStream.js
@@ -2,7 +2,7 @@ const hasYarn = require('has-yarn');
 const execa = require('execa');
 const merge = require('merge-stream');
 const ansi = require('ansi-html-stream');
-const _ = require('lodash');
+
 const theme = {
   resets: {
     '0': false,
@@ -38,21 +38,26 @@ const theme = {
 };
 
 // use this function to adjust arguments to yarn or npm
-const adjustArgument = arg => {
+const adjustSubCommand = arg => {
   switch (arg) {
     case 'remove':
       return 'uninstall';
     case 'add':
       return ['install', '--save'];
+    default:
+      return arg;
   }
 };
 
-module.exports = function ansiCommandStream({ args }) {
+module.exports = function ansiCommandStream({
+  args: [subCommand, ...subCommandArgs],
+}) {
   const command = hasYarn() ? 'yarn' : 'npm';
   // adjust arguments only if needed (only if it hasn't yarn)
-  const adjustedArguments = hasYarn()
-    ? args
-    : _.flatten(args.map(adjustArgument));
+  const adjustedArguments = [
+    hasYarn() ? subCommand : adjustSubCommand(subCommand),
+    subCommandArgs,
+  ].flatten();
 
   const { stdout, stderr, kill } = execa(command, [
     // '--color="always"',

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,1 @@
+require('core-js/modules/es7.array.flatten');

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -3,4 +3,6 @@ import 'jest-styled-components';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
+import '../src/polyfills';
+
 Enzyme.configure({ adapter: new Adapter() });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 


### PR DESCRIPTION
<!--

Thanks for your pull request! 🎊

-->

## Checklist

* [x] tests pass (`yarn test; yarn lint`)
* [x] I'm in `all-contributors` <!-- yarn all-contributors add myself what,i,did -->

# What's changed?

Replaced use of lodash with core-js polyfill for the flatten() method.

## Test plan

Added unit tests to cover install/remove dependencies.