### PR TITLE
refactor: group tests by has-yarn-ness

### DIFF
--- a/src/__tests__/ansiCommandStream.test.js
+++ b/src/__tests__/ansiCommandStream.test.js
@@ -11,35 +11,46 @@ describe('ansiCommandStream()', () => {
     jest.clearAllMocks();
   });
 
-  test('when yarn is installed use `yarn remove`', () => {
-    hasYarn.__setHasYarn(true);
-    ansiCommandStream({ args: ['remove', 'lodash'] });
+  describe('with yarn installed', () => {
+    beforeAll(() => {
+      hasYarn.__setHasYarn(true);
+    });
 
-    expect(execa).toHaveBeenCalledTimes(1);
-    expect(execa).toHaveBeenCalledWith('yarn', ['remove', 'lodash']);
+    test('use `yarn remove`', () => {
+      ansiCommandStream({ args: ['remove', 'lodash'] });
+
+      expect(execa).toHaveBeenCalledTimes(1);
+      expect(execa).toHaveBeenCalledWith('yarn', ['remove', 'lodash']);
+    });
+    test('use `yarn add`', () => {
+      ansiCommandStream({ args: ['add', 'lodash'] });
+
+      expect(execa).toHaveBeenCalledTimes(1);
+      expect(execa).toHaveBeenCalledWith('yarn', ['add', 'lodash']);
+    });
   });
 
-  test('when yarn is not installed use `npm uninstall`', () => {
-    hasYarn.__setHasYarn(false);
-    ansiCommandStream({ args: ['remove', 'lodash'] });
+  describe('when yarn is NOT installed', () => {
+    beforeAll(() => {
+      hasYarn.__setHasYarn(false);
+    });
 
-    expect(execa).toHaveBeenCalledTimes(1);
-    expect(execa).toHaveBeenCalledWith('npm', ['uninstall', 'lodash']);
-  });
+    test('use `npm uninstall`', () => {
+      ansiCommandStream({ args: ['remove', 'lodash'] });
 
-  test('when yarn is installed use `yarn add`', () => {
-    hasYarn.__setHasYarn(true);
-    ansiCommandStream({ args: ['add', 'lodash'] });
+      expect(execa).toHaveBeenCalledTimes(1);
+      expect(execa).toHaveBeenCalledWith('npm', ['uninstall', 'lodash']);
+    });
 
-    expect(execa).toHaveBeenCalledTimes(1);
-    expect(execa).toHaveBeenCalledWith('yarn', ['add', 'lodash']);
-  });
+    test('use `npm install --save`', () => {
+      ansiCommandStream({ args: ['add', 'lodash'] });
 
-  test('when yarn is not installed use `npm install --save`', () => {
-    hasYarn.__setHasYarn(false);
-    ansiCommandStream({ args: ['add', 'lodash'] });
-
-    expect(execa).toHaveBeenCalledTimes(1);
-    expect(execa).toHaveBeenCalledWith('npm', ['install', '--save', 'lodash']);
+      expect(execa).toHaveBeenCalledTimes(1);
+      expect(execa).toHaveBeenCalledWith('npm', [
+        'install',
+        '--save',
+        'lodash',
+      ]);
+    });
   });
 });

--- a/src/__tests__/ansiCommandStream.test.js
+++ b/src/__tests__/ansiCommandStream.test.js
@@ -11,18 +11,18 @@ describe('ansiCommandStream()', () => {
     jest.clearAllMocks();
   });
 
-  describe('with yarn installed', () => {
+  describe('with yarn', () => {
     beforeAll(() => {
       hasYarn.__setHasYarn(true);
     });
 
-    test('use `yarn remove`', () => {
+    test('uses `yarn remove`', () => {
       ansiCommandStream({ args: ['remove', 'lodash'] });
 
       expect(execa).toHaveBeenCalledTimes(1);
       expect(execa).toHaveBeenCalledWith('yarn', ['remove', 'lodash']);
     });
-    test('use `yarn add`', () => {
+    test('uses `yarn add`', () => {
       ansiCommandStream({ args: ['add', 'lodash'] });
 
       expect(execa).toHaveBeenCalledTimes(1);
@@ -30,19 +30,19 @@ describe('ansiCommandStream()', () => {
     });
   });
 
-  describe('when yarn is NOT installed', () => {
+  describe('without yarn', () => {
     beforeAll(() => {
       hasYarn.__setHasYarn(false);
     });
 
-    test('use `npm uninstall`', () => {
+    test('uses `npm uninstall`', () => {
       ansiCommandStream({ args: ['remove', 'lodash'] });
 
       expect(execa).toHaveBeenCalledTimes(1);
       expect(execa).toHaveBeenCalledWith('npm', ['uninstall', 'lodash']);
     });
 
-    test('use `npm install --save`', () => {
+    test('uses `npm install --save`', () => {
       ansiCommandStream({ args: ['add', 'lodash'] });
 
       expect(execa).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!--

Thanks for your pull request! 🎊

-->

## Checklist

* [x] tests pass (`yarn test; yarn lint`)
* [x] I'm in `all-contributors` <!-- yarn all-contributors add myself what,i,did -->

# What's changed?

Refactored tests as per https://github.com/Haroenv/dev-ui/pull/36#discussion_r160045822

## Test plan

Tests still pass